### PR TITLE
Use meraki chosen instead of drmonty-chosen

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/chenglou/react-chosen.git"
+    "url": "https://github.com/meraki/react-chosen.git"
   },
   "keywords": [
     "facebook",
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/chenglou/react-chosen",
   "dependencies": {
-    "drmonty-chosen": "^1.1.0",
     "jquery": "^2.1.1",
     "react": "^0.13.1"
   }

--- a/react-chosen.js
+++ b/react-chosen.js
@@ -60,7 +60,7 @@
       // chosen onto jQuery. Note that due to the nature of the third-party
       // chosen npm shim, we still need to manually include jQuery at the top
       // level.
-      require('drmonty-chosen');
+      require('script!private/javascripts/chosen.jquery.js');
       module.exports = Chosen;
     }
 })(


### PR DESCRIPTION
- drmonty-chosen does not include features added to meraki chosen so
  instead require the local copy of meraki chosen.
- Also updates the repository to the actual repository.
